### PR TITLE
added a service account to cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ jobs:
         uses: 'google-github-actions/auth@v3'
         with:
           project_id: '${{ env.PROJECT_ID }}'
+          service_account: "gh-actions-deployer@adroit-minutia-471316-f1.iam.gserviceaccount.com"
           workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
 
       # BEGIN - Docker auth and build


### PR DESCRIPTION
# Description

This pull request makes a minor update to the deployment workflow by specifying the service account used for authentication.

* Deployment workflow: Added the `service_account` field to the Google authentication step in `.github/workflows/cd.yml` to explicitly set the service account for GitHub Actions deployments.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore
