### PR TITLE
Setup.py corrected for GCP migration

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -1,6 +1,6 @@
 import os
 from src.logger import setup_logging
-from src.utils import duckdb_con_init, ducklake_init, ducklake_attach_minio, schema_creation
+from src.utils import duckdb_con_init, ducklake_init, ducklake_attach_gcp, schema_creation
 from dotenv import load_dotenv
 current_path = os.path.dirname(os.path.abspath(__file__))
 parent_path = os.path.abspath(os.path.join(current_path, ".."))
@@ -15,7 +15,7 @@ def setup():
     catalog_path = os.path.join(parent_path, "catalog.ducklake")
     con = duckdb_con_init()
     ducklake_init(con, data_path, catalog_path)
-    ducklake_attach_minio(con)
+    ducklake_attach_gcp(con)
     schema_creation(con)
     con.close()
     logger.info("Setup completed successfully")


### PR DESCRIPTION
# Description

This pull request updates the storage backend integration in the setup process to use Google Cloud Platform (GCP) instead of MinIO. The most important changes are:

Storage backend integration:

* Replaced the import of `ducklake_attach_minio` with `ducklake_attach_gcp` in `src/setup.py`, updating the storage attachment utility to use GCP.
* Changed the call from `ducklake_attach_minio(con)` to `ducklake_attach_gcp(con)` inside the `setup()` function, ensuring the setup process now attaches to GCP storage instead of MinIO.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Chore
