### PR TITLE
Uploading local Ducklake Catalog to GCS for Serverless API access

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -20,6 +20,7 @@ from .utils import (
     handle_date_adjustment,
     preprocess_apod_data,
     write_data_to_gcs,
+    update_catalog_to_gcs
 )
 
 __all__ = [
@@ -47,4 +48,5 @@ __all__ = [
     "handle_date_adjustment",
     "preprocess_apod_data",
     "write_data_to_gcs",
+    "update_catalog_to_gcs"
 ]

--- a/src/db_sync.py
+++ b/src/db_sync.py
@@ -1,6 +1,6 @@
 from src.logger import setup_logging
 import os
-from src.utils import duckdb_con_init, ducklake_init, ducklake_refresh, execute_SQL_file_list, update_data, ducklake_attach_gcp, gcs_path_exists
+from src.utils import duckdb_con_init, ducklake_init, ducklake_refresh, execute_SQL_file_list, update_data, ducklake_attach_gcp, gcs_path_exists, update_catalog_to_gcs
 from src.data_quality import passed_data_quality_checks
 from dotenv import load_dotenv
 from prefect import task
@@ -52,4 +52,5 @@ def db_sync():
     
     con.close()
     logger.info("Database connection closed")
+    update_catalog_to_gcs(gcp_bucket,catalog_path)
     logger.info("Database sync completed")

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,6 +1,6 @@
 import os
 from src.logger import setup_logging
-from src.utils import duckdb_con_init, ducklake_init, ducklake_attach_gcp, schema_creation
+from src.utils import duckdb_con_init, ducklake_init, ducklake_attach_gcp, schema_creation, update_catalog_to_gcs
 from dotenv import load_dotenv
 current_path = os.path.dirname(os.path.abspath(__file__))
 parent_path = os.path.abspath(os.path.join(current_path, ".."))
@@ -18,6 +18,7 @@ def setup():
     ducklake_attach_gcp(con)
     schema_creation(con)
     con.close()
+    update_catalog_to_gcs(gcp_bucket,catalog_path)
     logger.info("Setup completed successfully")
 
 if __name__ == "__main__":

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,6 +1,6 @@
 import os
 from src.logger import setup_logging
-from src.utils import duckdb_con_init, ducklake_init, ducklake_attach_minio, schema_creation
+from src.utils import duckdb_con_init, ducklake_init, ducklake_attach_gcp, schema_creation
 from dotenv import load_dotenv
 current_path = os.path.dirname(os.path.abspath(__file__))
 parent_path = os.path.abspath(os.path.join(current_path, ".."))
@@ -15,7 +15,7 @@ def setup():
     catalog_path = os.path.join(parent_path, "catalog.ducklake")
     con = duckdb_con_init()
     ducklake_init(con, data_path, catalog_path)
-    ducklake_attach_minio(con)
+    ducklake_attach_gcp(con)
     schema_creation(con)
     con.close()
     logger.info("Setup completed successfully")


### PR DESCRIPTION
# Description

This pull request adds a new utility function to upload the DuckLake catalog to Google Cloud Storage (GCS) and integrates it into both the database sync and setup workflows. The main changes involve the introduction of the `update_catalog_to_gcs` function, updates to relevant imports and exports, and the invocation of this function at the end of the database synchronization and setup processes.

**New GCS catalog upload functionality:**

* Added the `update_catalog_to_gcs` function in `src/utils.py`, which uploads the DuckLake catalog file to a specified GCS bucket and logs the result.
* Imported and exposed `update_catalog_to_gcs` in `src/__init__.py` to make it available for use throughout the project. [[1]](diffhunk://#diff-6b39a2f1a6399aa39e427fb4c11a7b552e615a2d83a3c36aa6dd6ddbbb8281f4R23) [[2]](diffhunk://#diff-6b39a2f1a6399aa39e427fb4c11a7b552e615a2d83a3c36aa6dd6ddbbb8281f4R51)

**Integration into workflows:**

* Updated `src/db_sync.py` and `src/setup.py` to import `update_catalog_to_gcs` and invoke it after completing their main operations, ensuring the catalog is always synced to GCS after database sync or setup. [[1]](diffhunk://#diff-1b99f73792ba09e9d5bded177e7d8bdc9629843878742576e4adffc7bc3b0982L3-R3) [[2]](diffhunk://#diff-1b99f73792ba09e9d5bded177e7d8bdc9629843878742576e4adffc7bc3b0982R55) [[3]](diffhunk://#diff-dd13c815bfaa701214fd8042095afca139f7c9cdce0b958860ee5a4cf9a2f5e7L3-R3) [[4]](diffhunk://#diff-dd13c815bfaa701214fd8042095afca139f7c9cdce0b958860ee5a4cf9a2f5e7R21)

**Environment setup:**

* Ensured environment variables are loaded in `src/utils.py` to support GCP authentication for the new upload function.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Chore
