### PR TITLE
Updated APOD Data Quality Check

### DIFF
--- a/SQL/data_quality/QUALITY_NASA_APOD.sql
+++ b/SQL/data_quality/QUALITY_NASA_APOD.sql
@@ -7,6 +7,4 @@ SELECT
     thumbnail_url,
     copyright
 FROM STAGED.NASA_APOD
-WHERE title IS NULL
-    OR explanation IS NULL
-    OR url IS NULL;
+WHERE title IS NULL;


### PR DESCRIPTION
# Description

This pull request makes a targeted change to the data quality filter in the `SQL/data_quality/QUALITY_NASA_APOD.sql` file, narrowing the criteria for selecting records with missing data.

Data quality filter update:

* The `WHERE` clause now only filters for records where `title` is `NULL`, instead of also checking if `explanation` or `url` are `NULL`.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore
