### PR TITLE
Updated Quality Checks

### DIFF
--- a/SQL/data_quality/QUALITY_NASA_APOD.sql
+++ b/SQL/data_quality/QUALITY_NASA_APOD.sql
@@ -7,6 +7,4 @@ SELECT
     thumbnail_url,
     copyright
 FROM STAGED.NASA_APOD
-WHERE title IS NULL
-    OR explanation IS NULL
-    OR url IS NULL;
+WHERE title IS NULL;


### PR DESCRIPTION
# Description

This pull request makes a small change to the data quality check in `SQL/data_quality/QUALITY_NASA_APOD.sql`. The filter condition has been updated to only check for rows where `title` is `NULL`, instead of also checking for `explanation` and `url`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore
