### PR TITLE
Updated staging SQL for APOD

### DIFF
--- a/SQL/staging/STAGED_NASA_APOD.sql
+++ b/SQL/staging/STAGED_NASA_APOD.sql
@@ -8,7 +8,4 @@ SELECT
     thumbnail_url,
     copyright
 FROM RAW_DATA.NASA_APOD
-WHERE date IS NOT NULL
-    AND title IS NOT NULL
-    AND url IS NOT NULL
-    AND explanation IS NOT NULL;
+WHERE title IS NOT NULL;


### PR DESCRIPTION
# Description

This pull request makes a small adjustment to the filtering logic in the `SQL/staging/STAGED_NASA_APOD.sql` file. The change simplifies the `WHERE` clause by only requiring that `title` is not null, rather than checking multiple fields.

* Simplified the `WHERE` clause in the `SELECT` statement to only require `title IS NOT NULL`, removing checks for `date`, `url`, and `explanation`.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore
